### PR TITLE
fix: Use an autorelease pool on macOS

### DIFF
--- a/Sources/Command.swift
+++ b/Sources/Command.swift
@@ -24,12 +24,14 @@ func checksum(url: URL, bufferSize: Int = 4 * 1024 * 1024) throws -> Data {
     }
 
     var md5 = Crypto.Insecure.MD5()
-    while true {
-        let data = file.readData(ofLength: bufferSize)
-        guard data.count > 0 else {
-            break
-        }
-        md5.update(data: data)
+    while autoreleasepool(invoking: {
+            let data = file.readData(ofLength: bufferSize)
+            guard data.count > 0 else {
+                return false
+            }
+            md5.update(data: data)
+            return true
+        }) {
     }
 
     return Data(md5.finalize())

--- a/Sources/Extensions/NSAutoreleasePool.swift
+++ b/Sources/Extensions/NSAutoreleasePool.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+#if os(Linux)
+
+@inlinable public func autoreleasepool<Result>(invoking body: () throws -> Result) rethrows -> Result {
+    return try body()
+}
+
+#endif


### PR DESCRIPTION
Unfotunately the memory models on macOS and Linux differ significantly and an autorelease pool—unavailable on Linux—is required on macOS to correctly manage memory usage.