### PR TITLE
refactor: Use a local submodule for Swift-SMTP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dependencies/Swift-SMTP"]
+	path = dependencies/Swift-SMTP
+	url = git@github.com:jbmorley/Swift-SMTP.git

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c724c32a8e84ded02c1501b8d4bb9462df8e99e942bd0fccb4139ef0c4e738a7",
+  "originHash" : "8ad6785b9bf0621086651faef72c459c8056b4012ecb4d13eac1551fb3cce2d8",
   "pins" : [
     {
       "identity" : "binarycodable",
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "e82d34eab3f0b05391082b11ea07d3b70d2f65bb",
         "version" : "1.9.200"
+      }
+    },
+    {
+      "identity" : "openssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Kitura/OpenSSL.git",
+      "state" : {
+        "revision" : "5dc8cb4f971135c17343e3c6df4f28904a0600e2",
+        "version" : "2.3.1"
       }
     },
     {
@@ -107,15 +116,6 @@
       "state" : {
         "revision" : "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
         "version" : "1.6.2"
-      }
-    },
-    {
-      "identity" : "swift-smtp",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Kitura/Swift-SMTP",
-      "state" : {
-        "revision" : "4b7666bb8cee33f0cb367786af17b9a2ebb63047",
-        "version" : "6.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -28,9 +28,9 @@ let package = Package(
         .macOS(.v12),
     ],
     dependencies: [
+        .package(path: "dependencies/Swift-SMTP"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/christophhagen/BinaryCodable", from: "3.0.0"),
-        .package(url: "https://github.com/Kitura/Swift-SMTP", from: "6.0.0"),
         .package(url: "https://github.com/stencilproject/Stencil.git", from: "0.15.1"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "4.0.0"),
     ],

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Reporter is written in Swift. [mise-en-place](https://mise.jdx.dev) is used to m
 ```shell
 git clone git@github.com:inseven/reporter.git
 cd reporter
+git submodule update --init --recursive
 mise install
 ```
 


### PR DESCRIPTION
This is preparatory work for fixing some issues in Swift-SMTP.