### PR TITLE
fix: Don't show unchanged folders in HTML emails

### DIFF
--- a/Sources/ReporterCore/Reporter.swift
+++ b/Sources/ReporterCore/Reporter.swift
@@ -313,7 +313,7 @@ public class Reporter {
         </style>
     </head>
     <body>
-        {% for item in report.folders %}
+        {% for item in report.folders %}{% if item.changes.changes.count > 1 %}
             <section class="folder">
                 <header>
                     <div class="name">{{ item.name }}</div>
@@ -332,7 +332,7 @@ public class Reporter {
                     </ul>
                 {% endif %}
             </section>
-        {% endfor %}
+        {% endif %}{% endfor %}
 
         <footer>
             <p>


### PR DESCRIPTION
Things can get pretty bloated if you include top-level entries for folders which haven't changed; this helps make it much easier to get a quick overview.