### PR TITLE
chore: ⬆️ Update submodules

### DIFF
--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -133,7 +133,7 @@ build-tools notarize "$BUILD_DIRECTORY/reporter" \
     --key "$API_KEY_PATH" \
     --key-id "$APPLE_API_KEY_ID" \
     --issuer "$APPLE_API_KEY_ISSUER_ID" \
-    --skip-staple
+    --log-directory "$BUILD_DIRECTORY"
 
 # Package up the build.
 cd "$BUILD_DIRECTORY"


### PR DESCRIPTION
scripts/build-tools:

- 7a52a62 fix: ⌨️ Support subcommand autocomplete (jbmorley/build-tools#26)
- 3418335 feat!: 🧨 Update version to 1.0.0 (jbmorley/build-tools#24)
- f65f70c feat! 🧨 Update version to 1.0.0 (jbmorley/build-tools#23)
- 07d918f fix: 🏃 Adopt `fastcommand` for command handling (jbmorley/build-tools#22)
- 148c303 fix: 🔐 Respect the provided password when creating a new keychain (jbmorley/build-tools#21)
- ba11843 fix: 📝 Add a PyPI summary description (jbmorley/build-tools#20)
- 3564f41 feat: 🚀 Publish to PyPI (jbmorley/build-tools#18)
- c13fe37 feat: 🏃 Notarize multiple bundles and binaries concurrently (jbmorley/build-tools#17)